### PR TITLE
Make the tests cross-platform

### DIFF
--- a/test/function-return/function-return.spec.js
+++ b/test/function-return/function-return.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('function-return', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './function-return.md'))

--- a/test/html-comment/html-comment.spec.js
+++ b/test/html-comment/html-comment.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('html-comment', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './html-comment.md'))

--- a/test/ignores-node/ignores-node.spec.js
+++ b/test/ignores-node/ignores-node.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('ignores-node', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './ignores-node.md'))

--- a/test/inline/inline.spec.js
+++ b/test/inline/inline.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('inline', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './inline.md'))

--- a/test/multiline/multiline.spec.js
+++ b/test/multiline/multiline.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('multiline', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './multiline.md'))

--- a/test/mutation/mutation.spec.js
+++ b/test/mutation/mutation.spec.js
@@ -1,7 +1,8 @@
 import { test } from 'zora'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { verify_file } from '../../src/verify_file.js'
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('mutation', async t => {
 	const { code, failed, output } = await verify_file(path.join(__dirname, './mutation.md'))


### PR DESCRIPTION
I was unable to run the tests on my Windows machine, because I was getting this error:

```
Error: ENOENT: no such file or directory, open 'C:\C:\Users\Joseph\Github\gfmjs\test\arrow-explicit-return\arrow-explicit-return.md'
```

Using `new URL(import.meta.url).pathname` [isn't cross platform](https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules#comment122817541_66651120).